### PR TITLE
Check author-box element exists before using it

### DIFF
--- a/src/common/yt-observer.js
+++ b/src/common/yt-observer.js
@@ -32,6 +32,12 @@ function replaceMessageEmotes(node, isMemberchat, isSuperchat) {
 		const header = card.querySelector("#header").querySelector("#header-content");
 		timestamp = header.querySelector("#timestamp").textContent;
 		authorBox = header.querySelector("#header-content-primary-column > #header-content-inner-column > yt-live-chat-author-chip");
+		if (!authorBox) {
+			// Rare error when skipping into a stream
+			// and membership messages appear before
+			// the observer has been disconnected.
+			return true;
+		}
 		authorName = authorBox.querySelector("#author-name").textContent;
 		message = card.querySelector("#content > #message");
 
@@ -41,6 +47,11 @@ function replaceMessageEmotes(node, isMemberchat, isSuperchat) {
 		const header = card.querySelector("#header").querySelector("#header-content");
 		timestamp = header.querySelector("#timestamp").textContent;
 		authorBox = header.querySelector("#header-content-primary-column > #single-line > #author-name-chip > yt-live-chat-author-chip");
+		if (!authorBox) {
+			// Haven't seen this with SCs but adding
+			// the same safety guard as for memberships.
+			return true;
+		}
 		authorName = authorBox.querySelector("#author-name").textContent;
 		message = card.querySelector("#content > #message");
 


### PR DESCRIPTION
The membership messages are initially added with a <dom-if> element/template inside the inner column.
That is later replaced with the actual dom structure. https://polymer-library.polymer-project.org/3.0/api/elements/dom-if

Can reproduce this error on stream OlaR3tnlg9g by starting at 0 seconds, and before the initial data has all been consumed jumping to the first highlight at 10:16.

All the membership messages in the chat box will initially appear as templates and so hit this error, but they don't need the html replacing anyway as they are patched during the fetch for those.